### PR TITLE
remove hook for JupyterHub

### DIFF
--- a/lib/vsc/eb_hooks/hooks_hydra.py
+++ b/lib/vsc/eb_hooks/hooks_hydra.py
@@ -262,26 +262,6 @@ end
 setenv("MCR_CACHE_ROOT", os.getenv("TMPDIR") or pathJoin("/tmp", os.getenv("USER")))
 """
 
-    # Set single MODULEPATH in JupyterHub
-    if self.name == 'JupyterHub':
-        mod_install_path = os.path.join(install_path('mod'), "all")
-        self.log.info("[parse hook] Setting single MODULEPATH on module load to: %s", mod_install_path[-9:])
-
-        # cannot know MODULEPATH in advance for archs with IB variants, use environment at load time
-        local_arch = os.getenv('VSC_ARCH_LOCAL') + os.getenv("VSC_ARCH_SUFFIX")
-        archless_path = [f'"{p}"' for p in mod_install_path.split(local_arch)]
-        if len(archless_path) > 1:
-            archless_path.insert(1, 'os.getenv("VSC_ARCH_LOCAL") .. os.getenv("VSC_ARCH_SUFFIX")')
-        modulepath = ", ".join(archless_path)
-
-        self.cfg['modluafooter'] = f"""
--- restrict MODULEPATH to current software generation
-if ( mode() ~= "spider" ) then
-    pushenv("MODULEPATH", "/etc/modulefiles/vsc")
-    prepend_path("MODULEPATH", pathJoin({modulepath}))
-end
-"""
-
     ##########################
     # ------ LICENSES ------ #
     ##########################

--- a/lib/vsc/eb_hooks/hooks_hydra.py
+++ b/lib/vsc/eb_hooks/hooks_hydra.py
@@ -23,7 +23,6 @@ import os
 from distutils.version import LooseVersion
 
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
-from easybuild.tools.config import install_path
 
 from vsc.eb_hooks.ib_modules import IB_MODULE_SOFTWARE, IB_MODULE_SUFFIX, IB_OPT_MARK
 


### PR DESCRIPTION
This is no longer needed:
* installations on skylakes with and without IB are separate
* changing `MODULEPATH` will be moved to the job script instead of this module